### PR TITLE
레시피 생성 후 Firestore 저장 기능 구현

### DIFF
--- a/lib/core/utils/error_mappers.dart
+++ b/lib/core/utils/error_mappers.dart
@@ -16,6 +16,8 @@ class ErrorMapper {
         return s.invalidImageError;
       case GenerateRecipeErrorKey.generationFailed:
         return s.generationFailedError;
+      case GenerateRecipeErrorKey.saveFailed:
+        return s.recipeSaveFailedError;
     }
   }
 }

--- a/lib/data/data_source/image_storage_data_source.dart
+++ b/lib/data/data_source/image_storage_data_source.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:firebase_storage/firebase_storage.dart';
 
 abstract class ImageStorageDataSource {
-  Future<String> uploadImage(File imageFile, String uid, String folder);
+  Future<String> uploadImageFile(File imageFile, String uid, String folder);
+  Future<String> uploadImageBytes(Uint8List imageBytes, String uid, String folder);
 }
 
 class FirebaseImageStorageDataSource implements ImageStorageDataSource {
@@ -11,12 +13,20 @@ class FirebaseImageStorageDataSource implements ImageStorageDataSource {
   FirebaseImageStorageDataSource(this._storage);
 
   @override
-  Future<String> uploadImage(File imageFile, String uid, String folder) async {
-    final ref = _storage.ref().child(
-      '$folder/$uid/${DateTime.now().millisecondsSinceEpoch}_${imageFile.path.split('/').last}',
-    );
+  Future<String> uploadImageFile(File imageFile, String uid, String folder) async {
+    final fileName = '${DateTime.now().millisecondsSinceEpoch}_${imageFile.path.split('/').last}';
+    final ref = _storage.ref().child('$folder/$uid/$fileName');
 
     await ref.putFile(imageFile);
+    return await ref.getDownloadURL();
+  }
+
+  @override
+  Future<String> uploadImageBytes(Uint8List imageBytes, String uid, String folder) async {
+    final fileName = '${DateTime.now().millisecondsSinceEpoch}.jpg';
+    final ref = _storage.ref().child('$folder/$uid/$fileName');
+
+    await ref.putData(imageBytes, SettableMetadata(contentType: 'image/jpeg'));
     return await ref.getDownloadURL();
   }
 }

--- a/lib/data/data_source/providers.dart
+++ b/lib/data/data_source/providers.dart
@@ -11,6 +11,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
+import '../repository/providers.dart';
+import '../repository/recipe_repository.dart';
 import 'firebase_auth_data_source.dart';
 import 'oauth_sign_in_data_source.dart';
 import '../../data/data_source/user_data_source.dart';
@@ -65,4 +67,8 @@ final recipeGenerationDataSourceProvider = Provider<RecipeGenerationDataSource>(
 
 final imageDownloadDataSourceProvider = Provider<ImageDownloadDataSource>(
       (ref) => DioImageDownloadDataSource(ref.read(dioProvider)),
+);
+
+final recipeRepositoryProvider = Provider<RecipeRepository>(
+      (ref) => RecipeRepositoryImpl(ref.read(recipeDataSourceProvider)),
 );

--- a/lib/data/data_source/recipe_data_source.dart
+++ b/lib/data/data_source/recipe_data_source.dart
@@ -1,0 +1,18 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../dto/recipe_firestore_dto.dart';
+
+abstract class RecipeDataSource {
+  Future<String> saveRecipe(RecipeFirestoreDto recipe);
+}
+
+class RecipeFirestoreDataSource implements RecipeDataSource {
+  final FirebaseFirestore _firestore;
+
+  RecipeFirestoreDataSource(this._firestore);
+
+  @override
+  Future<String> saveRecipe(RecipeFirestoreDto recipeDto) async {
+    final docRef = await _firestore.collection('recipes').add(recipeDto.toMap());
+    return docRef.id;
+  }
+}

--- a/lib/data/dto/recipe_firestore_dto.dart
+++ b/lib/data/dto/recipe_firestore_dto.dart
@@ -12,7 +12,7 @@ class RecipeFirestoreDto {
   final List<String> tags;
   final String userId;
   final String userName;
-  final String userProfileImage;
+  final String? userProfileImage;
   final bool isPublic;
   final String? imageUrl;
   final Timestamp createdAt;
@@ -28,7 +28,7 @@ class RecipeFirestoreDto {
     required this.tags,
     required this.userId,
     required this.userName,
-    required this.userProfileImage,
+    this.userProfileImage,
     required this.isPublic,
     required this.createdAt,
     this.imageUrl,
@@ -46,7 +46,7 @@ class RecipeFirestoreDto {
       tags: List<String>.from(map['tags'] ?? []),
       userId: map['userId'] ?? '',
       userName: map['userName'] ?? '',
-      userProfileImage: map['userProfileImage'] ?? '',
+      userProfileImage: map['userProfileImage'],
       isPublic: map['isPublic'] ?? false,
       imageUrl: map['imageUrl'],
       createdAt: map['createdAt'] ?? Timestamp.now(),

--- a/lib/data/repository/auth_repository.dart
+++ b/lib/data/repository/auth_repository.dart
@@ -1,6 +1,5 @@
 import 'package:cooki/app/enum/sign_in_method.dart';
 import 'package:cooki/data/dto/user_dto.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../domain/entity/app_user.dart';
 import '../data_source/firebase_auth_data_source.dart';

--- a/lib/data/repository/image_repository.dart
+++ b/lib/data/repository/image_repository.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
+import 'dart:typed_data';
 import '../data_source/image_storage_data_source.dart';
 
 abstract class ImageRepository {
-  Future<String> uploadImage(File imageFile, String uid, String folder);
+  Future<String> uploadImageFile(File imageFile, String uid, String folder);
+  Future<String> uploadImageBytes(Uint8List imageBytes, String uid, String folder);
 }
 
 class ImageRepositoryImpl implements ImageRepository {
@@ -11,7 +13,12 @@ class ImageRepositoryImpl implements ImageRepository {
   ImageRepositoryImpl(this._dataSource);
 
   @override
-  Future<String> uploadImage(File imageFile, String uid, String folder) {
-    return _dataSource.uploadImage(imageFile, uid, folder);
+  Future<String> uploadImageFile(File imageFile, String uid, String folder) {
+    return _dataSource.uploadImageFile(imageFile, uid, folder);
+  }
+
+  @override
+  Future<String> uploadImageBytes(Uint8List imageBytes, String uid, String folder) {
+    return _dataSource.uploadImageBytes(imageBytes, uid, folder);
   }
 }

--- a/lib/data/repository/providers.dart
+++ b/lib/data/repository/providers.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/repository/auth_repository.dart';
 import '../../data/repository/user_repository.dart';
 import '../data_source/providers.dart';
+import '../data_source/recipe_data_source.dart';
 import 'image_download_repository.dart';
 import 'image_repository.dart';
 
@@ -34,4 +35,8 @@ final recipeGenerationRepositoryProvider = Provider<RecipeGenerationRepository>(
 
 final imageDownloadRepositoryProvider = Provider<ImageDownloadRepository>(
       (ref) => ImageDownloadRepositoryImpl(ref.read(imageDownloadDataSourceProvider)),
+);
+
+final recipeDataSourceProvider = Provider<RecipeDataSource>(
+      (ref) => RecipeFirestoreDataSource(ref.read(firestoreProvider)),
 );

--- a/lib/data/repository/recipe_repository.dart
+++ b/lib/data/repository/recipe_repository.dart
@@ -1,0 +1,20 @@
+import '../../domain/entity/recipe.dart';
+import '../data_source/recipe_data_source.dart';
+import '../dto/recipe_firestore_dto.dart';
+
+abstract class RecipeRepository {
+  Future<String> saveRecipe(Recipe recipe);
+}
+
+class RecipeRepositoryImpl implements RecipeRepository {
+  final RecipeDataSource _recipeDataSource;
+
+  RecipeRepositoryImpl(this._recipeDataSource);
+
+  @override
+  Future<String> saveRecipe(Recipe recipe) async {
+    return await _recipeDataSource.saveRecipe(
+      RecipeFirestoreDto.fromEntity(recipe),
+    );
+  }
+}

--- a/lib/domain/entity/recipe.dart
+++ b/lib/domain/entity/recipe.dart
@@ -32,6 +32,7 @@ class Recipe {
   }) : createdAt = createdAt ?? DateTime.now();
 
   Recipe copyWith({
+    String? id,
     String? recipeName,
     List<String>? ingredients,
     List<String>? steps,
@@ -47,14 +48,14 @@ class Recipe {
     DateTime? createdAt,
   }) {
     return Recipe(
-      id: id,
+      id: id ?? this.id,
       recipeName: recipeName ?? this.recipeName,
-      ingredients: ingredients ?? List.from(this.ingredients),
-      steps: steps ?? List.from(this.steps),
+      ingredients: ingredients ?? this.ingredients,
+      steps: steps ?? this.steps,
       cookTime: cookTime ?? this.cookTime,
       calories: calories ?? this.calories,
       category: category ?? this.category,
-      tags: tags ?? List.from(this.tags),
+      tags: tags ?? this.tags,
       userId: userId ?? this.userId,
       userName: userName ?? this.userName,
       userProfileImage: userProfileImage ?? this.userProfileImage,

--- a/lib/domain/entity/recipe.dart
+++ b/lib/domain/entity/recipe.dart
@@ -9,7 +9,7 @@ class Recipe {
   final List<String> tags;
   final String userId;
   final String userName;
-  final String userProfileImage;
+  final String? userProfileImage;
   final bool isPublic;
   final String? imageUrl;
   final DateTime createdAt;
@@ -25,7 +25,7 @@ class Recipe {
     required this.tags,
     required this.userId,
     required this.userName,
-    required this.userProfileImage,
+    this.userProfileImage,
     required this.isPublic,
     this.imageUrl,
     DateTime? createdAt,

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -35,6 +35,7 @@
   "invalidUserInputError": "유효하지 않은 입력입니다.\n명확한 요리 설명 또는 재료를 입력해 주세요.",
   "invalidImageError": "레시피 생성에 실패했습니다.\n이미지에 음식이나 재료가 포함되어 있는지 확인해 주세요.",
   "generationFailedError": "레시피 생성에 실패했습니다.\n다시 시도해 주세요",
+  "recipeSaveFailedError": "레시피 저장에 실패했습니다.\n다시 시도해 주세요",
   "generateRecipeLoading": "레시피 생성 중...",
   "aiTextInputLabel": "AI 요청사항",
   "close": "닫기",

--- a/lib/presentation/pages/edit/recipe_edit_view_model.dart
+++ b/lib/presentation/pages/edit/recipe_edit_view_model.dart
@@ -1,5 +1,5 @@
+import 'package:cooki/domain/entity/recipe.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../domain/entity/generated_recipe.dart';
 
 /// How many items max to allow in either list
 const int recipeListMaxItems = 30;
@@ -22,9 +22,9 @@ class RecipeEditState {
 }
 
 class RecipeEditViewModel
-    extends AutoDisposeFamilyNotifier<RecipeEditState, GeneratedRecipe?> {
+    extends AutoDisposeFamilyNotifier<RecipeEditState, Recipe?> {
   @override
-  RecipeEditState build(GeneratedRecipe? arg) {
+  RecipeEditState build(Recipe? arg) {
     final ing = arg?.ingredients.length ?? 1;
     final stp = arg?.steps.length ?? 1;
     return RecipeEditState(
@@ -59,6 +59,6 @@ class RecipeEditViewModel
 }
 
 final recipeEditViewModelProvider = NotifierProvider.autoDispose
-    .family<RecipeEditViewModel, RecipeEditState, GeneratedRecipe?>(
+    .family<RecipeEditViewModel, RecipeEditState, Recipe?>(
   RecipeEditViewModel.new,
 );

--- a/lib/presentation/pages/generate/generate_recipe_page.dart
+++ b/lib/presentation/pages/generate/generate_recipe_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/constants/app_constants.dart';
+import '../../user_global_view_model.dart';
 import '../../widgets/input_decorations.dart';
 import 'generate_recipe_view_model.dart';
 
@@ -33,12 +34,24 @@ class GenerateRecipePage extends ConsumerWidget {
       );
       ref.read(generateRecipeViewModelProvider.notifier).clearError();
     } else if (state.generatedRecipe != null) {
+      // Save to Firestore
+      final user = ref.read(userGlobalViewModelProvider)!;
+      final savedRecipe = await ref
+          .read(generateRecipeViewModelProvider.notifier)
+          .saveGeneratedRecipe(
+            userId: user.id,
+            userName: user.name,
+            userProfileImage: user.profileImage ?? '',
+          );
+
       if (!context.mounted) return;
       Navigator.of(context).push(
         MaterialPageRoute(
           builder:
-              (context) =>
-                  RecipeEditPage(generatedRecipe: state.generatedRecipe),
+              (context) => RecipeEditPage(
+                generatedRecipe: state.generatedRecipe,
+                // savedRecipe: savedRecipe,
+              ),
         ),
       );
     }

--- a/lib/presentation/pages/generate/generate_recipe_view_model.dart
+++ b/lib/presentation/pages/generate/generate_recipe_view_model.dart
@@ -1,35 +1,39 @@
 import 'dart:typed_data';
 import 'package:cooki/core/utils/general_util.dart';
 import 'package:cooki/core/utils/logger.dart';
+import 'package:cooki/domain/entity/app_user.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../data/data_source/providers.dart';
 import '../../../data/repository/providers.dart';
 import '../../../domain/entity/generated_recipe.dart';
 import '../../../domain/entity/recipe.dart';
 
-enum GenerateRecipeErrorKey { invalidUserInput, invalidImage, generationFailed }
+enum GenerateRecipeErrorKey {
+  invalidUserInput,
+  invalidImage,
+  generationFailed,
+  saveFailed,
+}
 
 class GenerateRecipeState {
-  final bool isGenerating;
+  final bool isGeneratingAndSaving;
   final bool isLoadingImage;
   final GenerateRecipeErrorKey? errorKey;
   final Uint8List? selectedImageBytes;
   final String textInput;
   final Set<String> selectedPreferences;
-  final GeneratedRecipe? generatedRecipe;
 
   const GenerateRecipeState({
-    this.isGenerating = false,
+    this.isGeneratingAndSaving = false,
     this.isLoadingImage = false,
     this.errorKey,
     this.selectedImageBytes,
     this.textInput = '',
     this.selectedPreferences = const {},
-    this.generatedRecipe,
   });
 
   GenerateRecipeState copyWith({
-    bool? isGenerating,
+    bool? isGeneratingAndSaving,
     bool? isLoadingImage,
     GenerateRecipeErrorKey? errorKey,
     bool clearErrorKey = false,
@@ -37,10 +41,9 @@ class GenerateRecipeState {
     bool clearSelectedImageBytes = false,
     String? textInput,
     Set<String>? selectedPreferences,
-    GeneratedRecipe? generatedRecipe,
   }) {
     return GenerateRecipeState(
-      isGenerating: isGenerating ?? this.isGenerating,
+      isGeneratingAndSaving: isGeneratingAndSaving ?? this.isGeneratingAndSaving,
       isLoadingImage: isLoadingImage ?? this.isLoadingImage,
       errorKey: clearErrorKey ? null : errorKey ?? this.errorKey,
       selectedImageBytes:
@@ -49,13 +52,12 @@ class GenerateRecipeState {
               : selectedImageBytes ?? this.selectedImageBytes,
       textInput: textInput ?? this.textInput,
       selectedPreferences: selectedPreferences ?? this.selectedPreferences,
-      generatedRecipe: generatedRecipe ?? this.generatedRecipe,
     );
   }
 
   bool get canGenerate =>
       (textInput.trim().isNotEmpty || selectedImageBytes != null) &&
-      !isGenerating;
+      !isGeneratingAndSaving;
 
   bool get hasImage => selectedImageBytes != null;
 }
@@ -66,15 +68,37 @@ class GenerateRecipeViewModel extends AutoDisposeNotifier<GenerateRecipeState> {
     return const GenerateRecipeState();
   }
 
-  Future<void> generateRecipe({
+  Future<Recipe?> generateAndSaveRecipe({
+    required String textOnlyRecipePromptPath,
+    required String imageRecipePromptPath,
+    required AppUser user,
+  }) async {
+    state = state.copyWith(isGeneratingAndSaving: true);
+
+    try {
+      final generated = await _generateRecipe(
+        textOnlyRecipePromptPath: textOnlyRecipePromptPath,
+        imageRecipePromptPath: imageRecipePromptPath,
+      );
+      if (generated == null) return null;
+
+      final saved = await _saveRecipe(
+        generatedRecipe: generated,
+        user: user,
+      );
+      if (saved == null) return null;
+
+      return saved;
+    } finally {
+      state = state.copyWith(isGeneratingAndSaving: false);
+    }
+  }
+
+  Future<GeneratedRecipe?> _generateRecipe({
     required String textOnlyRecipePromptPath,
     required String imageRecipePromptPath,
   }) async {
-    if (!state.canGenerate) return;
-
-    state = state.copyWith(isGenerating: true);
     try {
-      // Validate input first if text is provided
       if (state.textInput.trim().isNotEmpty) {
         final validationResult = await ref
             .read(recipeGenerationRepositoryProvider)
@@ -82,16 +106,16 @@ class GenerateRecipeViewModel extends AutoDisposeNotifier<GenerateRecipeState> {
 
         if (!validationResult.isValid) {
           state = state.copyWith(
-            isGenerating: false,
             errorKey: GenerateRecipeErrorKey.invalidUserInput,
           );
-          return;
+          return null;
         }
       }
 
       final compressedImageBytes = await GeneralUtil.compressImageBytes(
         state.selectedImageBytes,
       );
+
       var generatedRecipe = await ref
           .read(recipeGenerationRepositoryProvider)
           .generateRecipe(
@@ -105,60 +129,53 @@ class GenerateRecipeViewModel extends AutoDisposeNotifier<GenerateRecipeState> {
             textOnlyRecipePromptPath: textOnlyRecipePromptPath,
             imageRecipePromptPath: imageRecipePromptPath,
           );
+
       if (generatedRecipe.isError) {
         state = state.copyWith(
-          isGenerating: false,
           errorKey:
               state.selectedImageBytes != null
                   ? GenerateRecipeErrorKey.invalidImage
                   : GenerateRecipeErrorKey.generationFailed,
         );
-      } else {
-        generatedRecipe = generatedRecipe.copyWith(
-          imageBytes: state.selectedImageBytes,
-        );
-        state = state.copyWith(
-          isGenerating: false,
-          generatedRecipe: generatedRecipe,
-        );
+        return null;
       }
+      return generatedRecipe.copyWith(imageBytes: state.selectedImageBytes);
     } catch (e, stack) {
       logError(e, stack);
-      state = state.copyWith(
-        isGenerating: false,
-        errorKey: GenerateRecipeErrorKey.generationFailed,
-      );
+      state = state.copyWith(errorKey: GenerateRecipeErrorKey.generationFailed);
+      return null;
     }
   }
 
-  Future<Recipe?> saveGeneratedRecipe({
-    required String userId,
-    required String userName,
-    required String userProfileImage,
+  Future<Recipe?> _saveRecipe({
+    required GeneratedRecipe generatedRecipe,
+    required AppUser user,
   }) async {
     try {
       final recipe = Recipe(
         id: '',
-        // Will be set by Firestore
-        recipeName: state.generatedRecipe!.recipeName,
-        ingredients: state.generatedRecipe!.ingredients,
-        steps: state.generatedRecipe!.steps,
-        cookTime: state.generatedRecipe!.cookTime,
-        calories: state.generatedRecipe!.calories,
-        category: state.generatedRecipe!.category,
-        tags: state.generatedRecipe!.tags,
-        userId: userId,
-        userName: userName,
-        userProfileImage: userProfileImage,
+        // Firestore will generate
+        recipeName: generatedRecipe.recipeName,
+        ingredients: generatedRecipe.ingredients,
+        steps: generatedRecipe.steps,
+        cookTime: generatedRecipe.cookTime,
+        calories: generatedRecipe.calories,
+        category: generatedRecipe.category,
+        tags: generatedRecipe.tags,
+        userId: user.id,
+        userName: user.name,
+        userProfileImage: user.profileImage,
         isPublic: false,
-        // Default to private
-        imageUrl: null, // TODO: Implement image upload
+        imageUrl: null,
       );
 
-      final recipeId =  await ref.read(recipeRepositoryProvider).saveRecipe(recipe);
+      final recipeId = await ref
+          .read(recipeRepositoryProvider)
+          .saveRecipe(recipe);
       return recipe.copyWith(id: recipeId);
     } catch (e, stack) {
       logError(e, stack);
+      state = state.copyWith(errorKey: GenerateRecipeErrorKey.saveFailed);
       return null;
     }
   }

--- a/lib/presentation/pages/generate/generate_recipe_view_model.dart
+++ b/lib/presentation/pages/generate/generate_recipe_view_model.dart
@@ -2,8 +2,10 @@ import 'dart:typed_data';
 import 'package:cooki/core/utils/general_util.dart';
 import 'package:cooki/core/utils/logger.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../data/data_source/providers.dart';
 import '../../../data/repository/providers.dart';
 import '../../../domain/entity/generated_recipe.dart';
+import '../../../domain/entity/recipe.dart';
 
 enum GenerateRecipeErrorKey { invalidUserInput, invalidImage, generationFailed }
 
@@ -126,6 +128,38 @@ class GenerateRecipeViewModel extends AutoDisposeNotifier<GenerateRecipeState> {
         isGenerating: false,
         errorKey: GenerateRecipeErrorKey.generationFailed,
       );
+    }
+  }
+
+  Future<Recipe?> saveGeneratedRecipe({
+    required String userId,
+    required String userName,
+    required String userProfileImage,
+  }) async {
+    try {
+      final recipe = Recipe(
+        id: '',
+        // Will be set by Firestore
+        recipeName: state.generatedRecipe!.recipeName,
+        ingredients: state.generatedRecipe!.ingredients,
+        steps: state.generatedRecipe!.steps,
+        cookTime: state.generatedRecipe!.cookTime,
+        calories: state.generatedRecipe!.calories,
+        category: state.generatedRecipe!.category,
+        tags: state.generatedRecipe!.tags,
+        userId: userId,
+        userName: userName,
+        userProfileImage: userProfileImage,
+        isPublic: false,
+        // Default to private
+        imageUrl: null, // TODO: Implement image upload
+      );
+
+      final recipeId =  await ref.read(recipeRepositoryProvider).saveRecipe(recipe);
+      return recipe.copyWith(id: recipeId);
+    } catch (e, stack) {
+      logError(e, stack);
+      return null;
     }
   }
 

--- a/lib/presentation/pages/generate/widgets/image_selector.dart
+++ b/lib/presentation/pages/generate/widgets/image_selector.dart
@@ -1,4 +1,3 @@
-import 'dart:developer';
 import 'dart:io';
 
 import 'package:easy_image_viewer/easy_image_viewer.dart';


### PR DESCRIPTION
### 🚀 내용
- 레시피 생성 시 Firestore에 레시피를 저장하도록 구현
- `RecipeEditPage`로 GeneratedRecipe 대신에 Recipe 엔티티 전달
- Firestore 연동을 위해 Recipe와 RecipeDto의 `userProfileImage` 필드를 nullable로 변경
- 이미지 업로드를 위한 `ImageRepository` 및 `ImageStorageDataSource`에 바이트 업로드 메서드 추가

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/951d9f7d-2944-4cb8-912f-c77fbac0ea91" width="200">
<img src="https://github.com/user-attachments/assets/93c2fcc6-110c-42e1-bfed-5f93f5df48a1" width="200">
