### PR TITLE
페시피 편집페이지와 상세 페이지에서 사용되는 태그 칩을 recipe_page_widgets의 TagChips 위젯으로 분리

### DIFF
--- a/lib/presentation/pages/edit/recipe_edit_page.dart
+++ b/lib/presentation/pages/edit/recipe_edit_page.dart
@@ -197,7 +197,7 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
 
                           const SizedBox(height: 20),
                           if (recipe != null)
-                            _buildTagChips(recipe!.tags),
+                            TagChips(recipe!.tags),
 
                           const SizedBox(height: 28),
                           Text(
@@ -303,33 +303,6 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
           ],
         ),
       ),
-    );
-  }
-
-  Widget _buildTagChips(List<String> tags) {
-    return Wrap(
-      spacing: 6,
-      runSpacing: 8,
-      children:
-          tags.map((tag) {
-            return Container(
-              padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 12),
-              decoration: ShapeDecoration(
-                shape: RoundedRectangleBorder(
-                  side: BorderSide(color: AppColors.greyScale400),
-                  borderRadius: BorderRadius.circular(18),
-                ),
-                color: Colors.white,
-              ),
-              child: DefaultTextStyle(
-                style: const TextStyle(color: Colors.black, fontSize: 13),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [Text(tag)],
-                ),
-              ),
-            );
-          }).toList(),
     );
   }
 

--- a/lib/presentation/widgets/recipe_page_widgets.dart
+++ b/lib/presentation/widgets/recipe_page_widgets.dart
@@ -9,7 +9,56 @@ class RecipePageWidgets {
     fontWeight: FontWeight.bold,
   );
 
-  static const servingsTitleStyle = TextStyle(fontSize: 17, fontWeight: FontWeight.bold);
+  static const servingsTitleStyle = TextStyle(
+    fontSize: 17,
+    fontWeight: FontWeight.bold,
+  );
+}
+
+class TagChips extends StatelessWidget {
+  final List<String> tags;
+  final double fontSize;
+  final double verticalPadding;
+  final double horizontalPadding;
+
+  const TagChips(
+    this.tags, {
+    super.key,
+    this.fontSize = 13,
+    this.verticalPadding = 5,
+    this.horizontalPadding = 12,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 8,
+      children:
+          tags.map((tag) {
+            return Container(
+              padding: EdgeInsets.symmetric(
+                vertical: verticalPadding,
+                horizontal: horizontalPadding,
+              ),
+              decoration: ShapeDecoration(
+                shape: RoundedRectangleBorder(
+                  side: BorderSide(color: AppColors.greyScale400),
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                color: Colors.white,
+              ),
+              child: DefaultTextStyle(
+                style: TextStyle(color: Colors.black, fontSize: fontSize),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [Text(tag)],
+                ),
+              ),
+            );
+          }).toList(),
+    );
+  }
 }
 
 class StepIndexLabel extends StatelessWidget {


### PR DESCRIPTION
### 🚀 내용
- 다음과 같이 사용:
```dart
TagChips(recipe.tags)
```

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/90413fdf-530a-42e0-8b81-26a03d78c7e3" width="200">
