### PR TITLE
feat: 모든 탭 fix. 레시피 필터링 및 정렬 로직 Firestore 쿼리 기반으로 구현

### DIFF
--- a/lib/data/data_source/recipe_data_source.dart
+++ b/lib/data/data_source/recipe_data_source.dart
@@ -1,18 +1,39 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../dto/recipe_firestore_dto.dart';
 
+enum RecipeSortType {
+  createdAtDescending, // default
+  ratingDescending, // most stars
+  cookTimeAscending, // fastest first
+}
+
 abstract class RecipeDataSource {
+  Future<List<RecipeFirestoreDto>> getMyRecipes(
+    String userId, {
+    bool? isPublic,
+    RecipeSortType sortType = RecipeSortType.ratingDescending,
+  });
+
+  Future<List<String>> getUserSavedRecipeIds(String userId);
+  
+  Future<List<RecipeFirestoreDto>> getUserSavedRecipes(
+    String userId, {
+    RecipeSortType sortType = RecipeSortType.ratingDescending,
+  });
+
+  Future<List<RecipeFirestoreDto>> getCommunityRecipes(
+    String userId, {
+    RecipeSortType sortType = RecipeSortType.ratingDescending,
+  });
+
+  Future<void> addToSavedRecipes(String userId, String recipeId);
+  Future<void> removeFromSavedRecipes(String userId, String recipeId);
+
   Future<String> saveRecipe(RecipeFirestoreDto recipe);
 
   Future<void> editRecipe(RecipeFirestoreDto recipeDto);
 
   Future<List<RecipeFirestoreDto>> getAllRecipes();
-
-  Future<List<RecipeFirestoreDto>> getUserRecipes(String userId);
-
-  Future<List<RecipeFirestoreDto>> getSharedRecipes();
-
-  Future<List<RecipeFirestoreDto>> getCommunityRecipes();
 
   Future<void> toggleRecipeShare(String recipeId, bool isPublic);
 
@@ -52,58 +73,108 @@ class RecipeFirestoreDataSource implements RecipeDataSource {
         .toList();
   }
 
+  Query<Map<String, dynamic>> _applySort(
+    Query<Map<String, dynamic>> query,
+    RecipeSortType sortType,
+  ) {
+    switch (sortType) {
+      case RecipeSortType.ratingDescending:
+        return query.orderBy('ratingSum', descending: true);
+      case RecipeSortType.cookTimeAscending:
+        return query.orderBy('cookTime', descending: false);
+      case RecipeSortType.createdAtDescending:
+        return query.orderBy('createdAt', descending: true);
+    }
+  }
+
   @override
-  Future<List<RecipeFirestoreDto>> getUserRecipes(String userId) async {
-    final querySnapshot =
-        await _firestore
-            .collection('recipes')
-            .where('userId', isEqualTo: userId)
-            .get();
+  Future<List<RecipeFirestoreDto>> getMyRecipes(
+    String userId, {
+    bool? isPublic,
+    RecipeSortType sortType = RecipeSortType.createdAtDescending,
+  }) async {
+    var query = _firestore
+        .collection('recipes')
+        .where('userId', isEqualTo: userId);
 
-    // Sort by createdAt in memory instead of using Firestore orderBy
-    final docs = querySnapshot.docs;
-    docs.sort((a, b) {
-      final aTimestamp = a.data()['createdAt'] as Timestamp?;
-      final bTimestamp = b.data()['createdAt'] as Timestamp?;
+    if (isPublic != null) {
+      query = query.where('isPublic', isEqualTo: isPublic);
+    }
 
-      if (aTimestamp == null && bTimestamp == null) return 0;
-      if (aTimestamp == null) return 1;
-      if (bTimestamp == null) return -1;
+    query = _applySort(query, sortType);
 
-      return bTimestamp.compareTo(aTimestamp); // Descending order
+    final snapshot = await query.get();
+    return snapshot.docs
+        .map((doc) => RecipeFirestoreDto.fromMap(doc.id, doc.data()))
+        .toList();
+  }
+
+  @override
+  Future<List<String>> getUserSavedRecipeIds(String userId) async {
+    final snapshot = await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('savedRecipes')
+        .get();
+    return snapshot.docs.map((doc) => doc.id).toList();
+  }
+
+  @override
+  Future<List<RecipeFirestoreDto>> getUserSavedRecipes(
+    String userId, {
+    RecipeSortType sortType = RecipeSortType.createdAtDescending,
+  }) async {
+    final savedRecipeIds = await getUserSavedRecipeIds(userId);
+    if (savedRecipeIds.isEmpty) return [];
+
+    var query = _firestore
+        .collection('recipes')
+        .where(FieldPath.documentId, whereIn: savedRecipeIds);
+    query = _applySort(query, sortType);
+
+    final recipeSnapshot = await query.get();
+    return recipeSnapshot.docs
+        .map((doc) => RecipeFirestoreDto.fromMap(doc.id, doc.data()))
+        .toList();
+  }
+
+  @override
+  Future<List<RecipeFirestoreDto>> getCommunityRecipes(
+    String userId, {
+    RecipeSortType sortType = RecipeSortType.createdAtDescending,
+  }) async {
+    var query = _firestore
+        .collection('recipes')
+        .where('isPublic', isEqualTo: true)
+        .where('userId', isNotEqualTo: userId);
+    query = _applySort(query, sortType);
+
+    final snapshot = await query.get();
+    return snapshot.docs
+        .map((doc) => RecipeFirestoreDto.fromMap(doc.id, doc.data()))
+        .toList();
+  }
+
+  @override
+  Future<void> addToSavedRecipes(String userId, String recipeId) async {
+    await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('savedRecipes')
+        .doc(recipeId)
+        .set({
+      'savedAt': FieldValue.serverTimestamp(),
     });
-
-    return docs
-        .map((doc) => RecipeFirestoreDto.fromMap(doc.id, doc.data()))
-        .toList();
   }
 
   @override
-  Future<List<RecipeFirestoreDto>> getSharedRecipes() async {
-    final querySnapshot =
-        await _firestore
-            .collection('recipes')
-            .where('isPublic', isEqualTo: true)
-            .orderBy('createdAt', descending: true)
-            .get();
-
-    return querySnapshot.docs
-        .map((doc) => RecipeFirestoreDto.fromMap(doc.id, doc.data()))
-        .toList();
-  }
-
-  @override
-  Future<List<RecipeFirestoreDto>> getCommunityRecipes() async {
-    final querySnapshot =
-        await _firestore
-            .collection('recipes')
-            .where('isPublic', isEqualTo: true)
-            .orderBy('createdAt', descending: true)
-            .get();
-
-    return querySnapshot.docs
-        .map((doc) => RecipeFirestoreDto.fromMap(doc.id, doc.data()))
-        .toList();
+  Future<void> removeFromSavedRecipes(String userId, String recipeId) async {
+    await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('savedRecipes')
+        .doc(recipeId)
+        .delete();
   }
 
   @override

--- a/lib/data/repository/recipe_repository.dart
+++ b/lib/data/repository/recipe_repository.dart
@@ -14,11 +14,27 @@ abstract class RecipeRepository {
 
   Future<List<Recipe>> getAllRecipes();
 
-  Future<List<Recipe>> getUserRecipes(String userId);
+  Future<List<Recipe>> getMyRecipes(
+    String userId, {
+    bool? isPublic,
+    RecipeSortType sortType,
+  });
 
-  Future<List<Recipe>> getSharedRecipes();
+  Future<List<Recipe>> getUserSavedRecipes(
+    String userId, {
+    RecipeSortType sortType,
+  });
 
-  Future<List<Recipe>> getCommunityRecipes();
+  Future<List<String>> getUserSavedRecipeIds(String userId);
+
+  Future<List<Recipe>> getCommunityRecipes(
+    String userId, {
+    RecipeSortType sortType,
+  });
+
+  Future<void> addToSavedRecipes(String userId, String recipeId);
+
+  Future<void> removeFromSavedRecipes(String userId, String recipeId);
 
   Future<void> toggleRecipeShare(String recipeId, bool isPublic);
 
@@ -33,14 +49,12 @@ class RecipeRepositoryImpl implements RecipeRepository {
 
   @override
   Future<String> saveRecipe(Recipe recipe) async {
-    return await _recipeDataSource.saveRecipe(
-      RecipeFirestoreDto.fromEntity(recipe),
-    );
+    return _recipeDataSource.saveRecipe(RecipeFirestoreDto.fromEntity(recipe));
   }
 
   @override
-  Future<void> editRecipe(Recipe recipe) async {
-    await _recipeDataSource.editRecipe(RecipeFirestoreDto.fromEntity(recipe));
+  Future<void> editRecipe(Recipe recipe) {
+    return _recipeDataSource.editRecipe(RecipeFirestoreDto.fromEntity(recipe));
   }
 
   @override
@@ -59,30 +73,65 @@ class RecipeRepositoryImpl implements RecipeRepository {
   }
 
   @override
-  Future<List<Recipe>> getUserRecipes(String userId) async {
-    final recipeDtoList = await _recipeDataSource.getUserRecipes(userId);
-    return recipeDtoList.map((dto) => dto.toEntity()).toList();
+  Future<List<Recipe>> getMyRecipes(
+    String userId, {
+    bool? isPublic,
+    RecipeSortType sortType = RecipeSortType.createdAtDescending,
+  }) async {
+    final dtoList = await _recipeDataSource.getMyRecipes(
+      userId,
+      isPublic: isPublic,
+      sortType: sortType,
+    );
+    return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
-  Future<List<Recipe>> getSharedRecipes() async {
-    final recipeDtoList = await _recipeDataSource.getSharedRecipes();
-    return recipeDtoList.map((dto) => dto.toEntity()).toList();
+  Future<List<Recipe>> getUserSavedRecipes(
+    String userId, {
+    RecipeSortType sortType = RecipeSortType.createdAtDescending,
+  }) async {
+    final dtoList = await _recipeDataSource.getUserSavedRecipes(
+      userId,
+      sortType: sortType,
+    );
+    return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
-  Future<List<Recipe>> getCommunityRecipes() async {
-    final recipeDtoList = await _recipeDataSource.getCommunityRecipes();
-    return recipeDtoList.map((dto) => dto.toEntity()).toList();
+  Future<List<String>> getUserSavedRecipeIds(String userId) {
+    return _recipeDataSource.getUserSavedRecipeIds(userId);
   }
 
   @override
-  Future<void> toggleRecipeShare(String recipeId, bool isPublic) async {
-    await _recipeDataSource.toggleRecipeShare(recipeId, isPublic);
+  Future<List<Recipe>> getCommunityRecipes(
+    String userId, {
+    RecipeSortType sortType = RecipeSortType.createdAtDescending,
+  }) async {
+    final dtoList = await _recipeDataSource.getCommunityRecipes(
+      userId,
+      sortType: sortType,
+    );
+    return dtoList.map((dto) => dto.toEntity()).toList();
   }
 
   @override
-  Future<void> deleteRecipe(String recipeId) async {
-    await _recipeDataSource.deleteRecipe(recipeId);
+  Future<void> addToSavedRecipes(String userId, String recipeId) {
+    return _recipeDataSource.addToSavedRecipes(userId, recipeId);
+  }
+
+  @override
+  Future<void> removeFromSavedRecipes(String userId, String recipeId) {
+    return _recipeDataSource.removeFromSavedRecipes(userId, recipeId);
+  }
+
+  @override
+  Future<void> toggleRecipeShare(String recipeId, bool isPublic) {
+    return _recipeDataSource.toggleRecipeShare(recipeId, isPublic);
+  }
+
+  @override
+  Future<void> deleteRecipe(String recipeId) {
+    return _recipeDataSource.deleteRecipe(recipeId);
   }
 }

--- a/lib/presentation/pages/edit/recipe_edit_page.dart
+++ b/lib/presentation/pages/edit/recipe_edit_page.dart
@@ -75,7 +75,7 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
           showIcon: true,
         );
         // Refresh the recipe lists
-        ref.read(savedRecipesViewModelProvider.notifier).refreshRecipes();
+        ref.read(savedRecipesViewModelProvider(strings(context)).notifier).refreshRecipes();
         Navigator.of(context).popUntil((route) => route.isFirst);
         // Navigator.of(context).pop(true); // Return true to indicate success
       }

--- a/lib/presentation/pages/home/tabs/community/community_tab.dart
+++ b/lib/presentation/pages/home/tabs/community/community_tab.dart
@@ -74,14 +74,20 @@ class _CommunityPageState extends ConsumerState<CommunityPage> {
                   ...state.selectedCuisines.map(
                     (cuisine) => _FilterChip(
                       label: cuisine,
-                      onDeleted: () => viewModel.removeCuisine(cuisine),
+                      onDeleted: () async {
+                        viewModel.removeCuisine(cuisine);
+                        await viewModel.loadRecipes();
+                      },
                       isModalChip: false,
                     ),
                   ),
                   if (state.selectedSort.isNotEmpty)
                     _FilterChip(
                       label: state.selectedSort,
-                      onDeleted: () => viewModel.clearSort(),
+                      onDeleted: () async {
+                        viewModel.clearSort();
+                        await viewModel.loadRecipes();
+                      },
                       isModalChip: false,
                     ),
                 ],
@@ -363,8 +369,9 @@ class _CommunityPageState extends ConsumerState<CommunityPage> {
                               children: [
                                 Expanded(
                                   child: OutlinedButton(
-                                    onPressed: () {
+                                    onPressed: () async {
                                       viewModel.resetFilters();
+                                      await viewModel.loadRecipes();
                                       Navigator.pop(context);
                                     },
                                     child: Text(strings(context).reset),
@@ -373,11 +380,12 @@ class _CommunityPageState extends ConsumerState<CommunityPage> {
                                 const SizedBox(width: 12),
                                 Expanded(
                                   child: ElevatedButton(
-                                    onPressed: () {
+                                    onPressed: () async {
                                       viewModel.updateSelectedSort(tempSort);
                                       viewModel.updateSelectedCuisines(
                                         List.from(tempCuisines),
                                       );
+                                      await viewModel.loadRecipes();
                                       Navigator.pop(context);
                                     },
                                     style: ElevatedButton.styleFrom(
@@ -578,37 +586,37 @@ class _RecipeCard extends StatelessWidget {
                         ),
                       ],
                     ),
-                    Row(
-                      children: [
-                        CircleAvatar(
-                          radius: 10,
-                          backgroundImage:
-                              recipe.userProfileImage != null
-                                  ? NetworkImage(recipe.userProfileImage!)
-                                  : null,
-                          backgroundColor: AppColors.greyScale200,
-                          child:
-                              recipe.userProfileImage == null
-                                  ? const Icon(
-                                    Icons.person,
-                                    size: 12,
-                                    color: AppColors.greyScale600,
-                                  )
-                                  : null,
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            recipe.userName,
-                            style: const TextStyle(
-                              fontSize: 12,
-                              color: AppColors.greyScale600,
-                            ),
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
-                    ),
+                    // Row(
+                    //   children: [
+                    //     CircleAvatar(
+                    //       radius: 10,
+                    //       backgroundImage:
+                    //           recipe.userProfileImage != null
+                    //               ? NetworkImage(recipe.userProfileImage!)
+                    //               : null,
+                    //       backgroundColor: AppColors.greyScale200,
+                    //       child:
+                    //           recipe.userProfileImage == null
+                    //               ? const Icon(
+                    //                 Icons.person,
+                    //                 size: 12,
+                    //                 color: AppColors.greyScale600,
+                    //               )
+                    //               : null,
+                    //     ),
+                    //     const SizedBox(width: 8),
+                    //     Expanded(
+                    //       child: Text(
+                    //         recipe.userName,
+                    //         style: const TextStyle(
+                    //           fontSize: 12,
+                    //           color: AppColors.greyScale600,
+                    //         ),
+                    //         overflow: TextOverflow.ellipsis,
+                    //       ),
+                    //     ),
+                    //   ],
+                    // ),
                   ],
                 ),
               ),

--- a/lib/presentation/pages/home/tabs/community/community_tab_view_model.dart
+++ b/lib/presentation/pages/home/tabs/community/community_tab_view_model.dart
@@ -1,5 +1,7 @@
+import 'package:cooki/presentation/user_global_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../../core/utils/logger.dart';
 import '../../../../../data/repository/providers.dart';
 import '../../../../../domain/entity/recipe.dart';
 import '../../../../../core/utils/general_util.dart';
@@ -62,7 +64,7 @@ class CommunityState {
 class CommunityViewModel extends AutoDisposeNotifier<CommunityState> {
   @override
   CommunityState build() {
-    loadRecipes();
+    Future.microtask(() => loadRecipes());
     return const CommunityState();
   }
 
@@ -71,9 +73,10 @@ class CommunityViewModel extends AutoDisposeNotifier<CommunityState> {
 
     try {
       final repository = ref.read(recipeRepositoryProvider);
-      final recipes = await repository.getSharedRecipes();
+      final recipes = await repository.getCommunityRecipes(ref.read(userGlobalViewModelProvider)!.id);
       state = state.copyWith(isLoading: false, recipes: recipes);
-    } catch (e) {
+    } catch (e, stack) {
+      logError(e, stack);
       state = state.copyWith(isLoading: false, error: e.toString());
     }
   }


### PR DESCRIPTION
### 🚀 내용
- 생성한 레시피 탭 구현
- 저장한 레시피 탭 구현
- 기존 ViewModel 내 수동 필터링(getFilteredRecipes) 제거
- DataSource 및 Repository에서 정렬 및 공개 여부 기반 필터링 쿼리 처리
- 저장된 레시피(Saved) 조회 시 저장 여부 리스트 한 번에 불러오도록 최적화
- ViewModel에서 선택된 카테고리/정렬/카테고리에 따라 적절한 쿼리 메서드 호출
- 필터 및 정렬 변경 시 loadRecipes() 재호출하여 UI 즉시 반영
- PageView 탭 변경 시 ViewModel 상태 갱신 및 레시피 로딩 적용

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/a2877d65-a703-433a-8f1e-d5a1e029fb2b" width="200">

### Closes #92 #102 #100